### PR TITLE
Fix incorrect comments regarding the page names

### DIFF
--- a/pages/about.php
+++ b/pages/about.php
@@ -1,5 +1,5 @@
 <?php 
-	/* Template Name: Contact */ 
+	/* Template Name: About */ 
 ?>
 
 <?php get_header(); ?>

--- a/pages/contact.php
+++ b/pages/contact.php
@@ -1,5 +1,5 @@
 <?php 
-	/* Template Name: About */ 
+	/* Template Name: Contact */ 
 ?>
 
 <?php get_header(); ?>


### PR DESCRIPTION
The comment in pages/about.php stated that the name of the template is
'Contact', and the comment in pages/contact.php stated the name of the
template is 'About'. I believe this should be reversed.